### PR TITLE
feat(ci): automate daily nginx version builds

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
       - dev
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build_and_push:
@@ -12,26 +19,78 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Detect latest nginx alpine-slim version
+        id: nginx_version
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          latest_version=$(python3 - <<'PY'
+          import json
+          import re
+          import urllib.request
+
+          url = "https://hub.docker.com/v2/repositories/library/nginx/tags?page_size=100"
+          pattern = re.compile(r"^(\d+\.\d+\.\d+)-alpine-slim$")
+          versions = []
+
+          while url:
+              with urllib.request.urlopen(url) as response:
+                  data = json.load(response)
+
+              for tag in data.get("results", []):
+                  name = tag.get("name", "")
+                  match = pattern.match(name)
+                  if match:
+                      versions.append(match.group(1))
+
+              url = data.get("next")
+
+          if not versions:
+              raise SystemExit("No nginx alpine-slim version tags found")
+
+          def key(version):
+              return tuple(int(part) for part in version.split("."))
+
+          print(max(versions, key=key))
+          PY
+          )
+
+          echo "latest_version=$latest_version" >> "$GITHUB_OUTPUT"
+
+          if docker manifest inspect "ghcr.io/${REPOSITORY_OWNER}/nginx-unraid:${latest_version}" > /dev/null 2>&1; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "Image tag ${latest_version} already exists in GHCR. Skipping build."
+          else
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "New nginx version ${latest_version} found. Building image."
+          fi
+
       - name: Build and push
-        uses: docker/build-push-action@v2
+        if: steps.nginx_version.outputs.should_build == 'true'
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: true
+          build-args: |
+            NGINX_BASE_TAG=${{ steps.nginx_version.outputs.latest_version }}-alpine-slim
           tags: |
-            ghcr.io/${{ github.repository_owner }}/nginx-unraid:${{ github.ref == 'refs/heads/main' && 'latest' || format('{0}-{1}', github.ref_name, github.run_number) }}
+            ghcr.io/${{ github.repository_owner }}/nginx-unraid:${{ steps.nginx_version.outputs.latest_version }}
+            ghcr.io/${{ github.repository_owner }}/nginx-unraid:latest
 
       - name: Logout from Docker
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM nginx:alpine-slim
+ARG NGINX_BASE_TAG=alpine-slim
+FROM nginx:${NGINX_BASE_TAG}
 ARG TARGETPLATFORM
 # Set env vars
 ENV SUPPRESS_NO_CONFIG_WARNING=1 \


### PR DESCRIPTION
## What
- add daily scheduled workflow run plus manual trigger
- detect latest upstream nginx alpine-slim version from Docker Hub
- skip build when version tag already exists in GHCR
- build and push new image tags for version and latest
- allow Dockerfile base image to be set via build arg

## Why
Critical nginx bugs appear frequently. This automates checking and publishing rebuilt images when new nginx versions are available.